### PR TITLE
⚡️ [Feature/invitation-34] 초대 수락/거절 기능 구현

### DIFF
--- a/src/main/java/com/jungdam/common/dto/ResponseMessage.java
+++ b/src/main/java/com/jungdam/common/dto/ResponseMessage.java
@@ -13,6 +13,7 @@ public enum ResponseMessage {
     DIARY_CREATE_SUCCESS(HttpStatus.CREATED, "일기 생성 성공"),
     INVITATION_CREATE_SUCCESS(HttpStatus.CREATED, "초대 생성 성공"),
     INVITATION_READ_ALL_SUCCESS(HttpStatus.OK, "초대 목록 조회 성공"),
+    INVITATION_UPDATE_SUCCESS(HttpStatus.OK, "초대 수락/거절 성공"),
     PARTICIPANT_READ_SUCCESS(HttpStatus.OK, "멤버 리스트 조회 성공"),
     DIARY_READ_SUCCESS(HttpStatus.OK, "일기 조회 성공"),
     COMMENT_CREATE_SUCCESS(HttpStatus.CREATED, "댓글 생성 성공"),

--- a/src/main/java/com/jungdam/error/ErrorMessage.java
+++ b/src/main/java/com/jungdam/error/ErrorMessage.java
@@ -6,6 +6,8 @@ public enum ErrorMessage {
 
     NOT_EXIST_MEMBER(HttpStatus.NOT_FOUND, "존재하지 않는 회원입니다."),
 
+    NO_PERMISSION_INVITATION_UPDATE(HttpStatus.FORBIDDEN, "초대 수정 권한이 없습니다."),
+
     INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "잘못된 입력입니다."),
     NOT_EXIST_PROVIDER_TYPE(HttpStatus.BAD_REQUEST, "존재하지 않는 제공자 타입입니다."),
     FAIL_TO_GENERATE_TOKEN(HttpStatus.BAD_REQUEST, "토큰 생성 실패"),

--- a/src/main/java/com/jungdam/error/ErrorMessage.java
+++ b/src/main/java/com/jungdam/error/ErrorMessage.java
@@ -22,6 +22,7 @@ public enum ErrorMessage {
     NOT_EXIST_DIARY(HttpStatus.BAD_REQUEST, "존재하지 않는 일기입니다."),
     DUPLICATION_PARTICIPANT_IN_ALBUM(HttpStatus.BAD_REQUEST, "해당 앨범에 회원이 존재합니다."),
     DUPLICATION_INVITATION_IN_ALBUM(HttpStatus.BAD_REQUEST, "해당 앨범에 회원을 초대 후 대기 상태입니다."),
+    INVALID_INVITATION_STATUS(HttpStatus.BAD_REQUEST, "형식에 맞지 않는 초대 상태입니다."),
     INVALID_COMMENT_CONTENT(HttpStatus.BAD_REQUEST, "댓글의 형식이 잘못되었습니다."),
     INVALID_DIARY_PHOTO_IMAGE(HttpStatus.BAD_REQUEST, "이미지 정보가 잘못되었습니다."),
     INVALID_ALBUM_TITLE(HttpStatus.BAD_REQUEST, "형식에 맞지 않는 앨범 제목입니다."),

--- a/src/main/java/com/jungdam/invitation/application/InvitationService.java
+++ b/src/main/java/com/jungdam/invitation/application/InvitationService.java
@@ -3,6 +3,7 @@ package com.jungdam.invitation.application;
 import com.jungdam.album.domain.Album;
 import com.jungdam.error.ErrorMessage;
 import com.jungdam.error.exception.DuplicationException;
+import com.jungdam.error.exception.NoPermissionException;
 import com.jungdam.invitation.domain.Invitation;
 import com.jungdam.invitation.domain.vo.Status;
 import com.jungdam.invitation.infrastructure.InvitationRepository;
@@ -29,8 +30,20 @@ public class InvitationService {
     }
 
     @Transactional(readOnly = true)
+    public Invitation findByIdAndTargetMemberAndPendingStatus(Long id, Member member) {
+        return invitationRepository.findByIdAndTargetMemberAndStatus(id, member, Status.PENDING)
+            .orElseThrow(() -> new NoPermissionException(ErrorMessage.NO_PERMISSION_INVITATION_UPDATE));
+    }
+
+    @Transactional(readOnly = true)
     public List<Invitation> findAllByTargetMemberAndPendingStatus(Member member) {
         return invitationRepository.findAllByTargetMemberAndStatus(member, Status.PENDING);
+    }
+
+    @Transactional
+    public boolean existsByAlbumAndTargetMemberAndStatus(Album album, Member member,
+        Status status) {
+        return invitationRepository.existsByAlbumAndTargetMemberAndStatus(album, member, status);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/jungdam/invitation/converter/InvitationConverter.java
+++ b/src/main/java/com/jungdam/invitation/converter/InvitationConverter.java
@@ -4,6 +4,7 @@ import com.jungdam.album.domain.Album;
 import com.jungdam.invitation.domain.Invitation;
 import com.jungdam.invitation.dto.response.CreateInvitationResponse;
 import com.jungdam.invitation.dto.response.ReadAllInvitationResponse;
+import com.jungdam.invitation.dto.response.UpdateInvitationResponse;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.springframework.stereotype.Component;
@@ -25,5 +26,9 @@ public class InvitationConverter {
                     .albumTitle(album.getTitleValue())
                     .build();
             }).collect(Collectors.toList());
+    }
+
+    public UpdateInvitationResponse toUpdateInvitationResponse(Invitation invitation) {
+        return new UpdateInvitationResponse(invitation.getId(), invitation.getStatus());
     }
 }

--- a/src/main/java/com/jungdam/invitation/domain/Invitation.java
+++ b/src/main/java/com/jungdam/invitation/domain/Invitation.java
@@ -52,6 +52,10 @@ public class Invitation extends BaseEntity {
         this.album = album;
     }
 
+    public void updateStatus(Status status) {
+        this.status = status;
+    }
+
     public Long getId() {
         return id;
     }

--- a/src/main/java/com/jungdam/invitation/domain/vo/Status.java
+++ b/src/main/java/com/jungdam/invitation/domain/vo/Status.java
@@ -1,7 +1,28 @@
 package com.jungdam.invitation.domain.vo;
 
+import com.jungdam.error.ErrorMessage;
+import com.jungdam.error.exception.InvalidArgumentException;
+import java.util.Arrays;
+
 public enum Status {
-    ACCEPT,
-    REJECT,
-    PENDING;
+    ACCEPT("ACCEPT"),
+    REJECT("REJECT"),
+    PENDING("PENDING");
+
+    private final String status;
+
+    Status(String status) {
+        this.status = status;
+    }
+
+    public static Status from(String status) {
+        return Arrays.stream(values())
+            .filter(s -> s.getStatus().equals(status))
+            .findAny()
+            .orElseThrow(() -> new InvalidArgumentException(ErrorMessage.INVALID_INVITATION_STATUS));
+    }
+
+    public String getStatus() {
+        return status;
+    }
 }

--- a/src/main/java/com/jungdam/invitation/dto/bundle/UpdateInvitationBundle.java
+++ b/src/main/java/com/jungdam/invitation/dto/bundle/UpdateInvitationBundle.java
@@ -12,7 +12,7 @@ public class UpdateInvitationBundle {
     public UpdateInvitationBundle(Long memberId, Long invitationId, UpdateInvitationRequest request) {
         this.memberId = memberId;
         this.invitationId = invitationId;
-        this.status = request.getStatus();
+        this.status = Status.from(request.getStatus());
     }
 
     public static UpdateInvitationResponseBuilder builder() {

--- a/src/main/java/com/jungdam/invitation/dto/bundle/UpdateInvitationBundle.java
+++ b/src/main/java/com/jungdam/invitation/dto/bundle/UpdateInvitationBundle.java
@@ -1,0 +1,63 @@
+package com.jungdam.invitation.dto.bundle;
+
+import com.jungdam.invitation.domain.vo.Status;
+import com.jungdam.invitation.dto.request.UpdateInvitationRequest;
+
+public class UpdateInvitationBundle {
+
+    private final Long memberId;
+    private final Long invitationId;
+    private final Status status;
+
+    public UpdateInvitationBundle(Long memberId, Long invitationId, UpdateInvitationRequest request) {
+        this.memberId = memberId;
+        this.invitationId = invitationId;
+        this.status = request.getStatus();
+    }
+
+    public static UpdateInvitationResponseBuilder builder() {
+        return new UpdateInvitationResponseBuilder();
+    }
+
+    public Long getMemberId() {
+        return memberId;
+    }
+
+    public Long getInvitationId() {
+        return invitationId;
+    }
+
+    public Status getStatus() {
+        return status;
+    }
+
+    public static class UpdateInvitationResponseBuilder {
+
+        private Long memberId;
+        private Long invitationId;
+        private UpdateInvitationRequest request;
+
+        private UpdateInvitationResponseBuilder() {
+        }
+
+        public UpdateInvitationResponseBuilder memberId(final Long memberId) {
+            this.memberId = memberId;
+            return this;
+        }
+
+        public UpdateInvitationResponseBuilder invitationId(final Long invitationId) {
+            this.invitationId = invitationId;
+            return this;
+        }
+
+        public UpdateInvitationResponseBuilder request(final UpdateInvitationRequest request) {
+            this.request = request;
+            return this;
+        }
+
+        public UpdateInvitationBundle build() {
+            return new UpdateInvitationBundle(this.memberId, this.invitationId, this.request);
+        }
+    }
+
+}

--- a/src/main/java/com/jungdam/invitation/dto/request/UpdateInvitationRequest.java
+++ b/src/main/java/com/jungdam/invitation/dto/request/UpdateInvitationRequest.java
@@ -1,0 +1,15 @@
+package com.jungdam.invitation.dto.request;
+
+import com.jungdam.invitation.domain.vo.Status;
+
+public class UpdateInvitationRequest {
+
+    private Status status;
+
+    protected UpdateInvitationRequest() {
+    }
+
+    public Status getStatus() {
+        return status;
+    }
+}

--- a/src/main/java/com/jungdam/invitation/dto/request/UpdateInvitationRequest.java
+++ b/src/main/java/com/jungdam/invitation/dto/request/UpdateInvitationRequest.java
@@ -1,15 +1,13 @@
 package com.jungdam.invitation.dto.request;
 
-import com.jungdam.invitation.domain.vo.Status;
-
 public class UpdateInvitationRequest {
 
-    private Status status;
+    private String status;
 
     protected UpdateInvitationRequest() {
     }
 
-    public Status getStatus() {
+    public String getStatus() {
         return status;
     }
 }

--- a/src/main/java/com/jungdam/invitation/dto/response/UpdateInvitationResponse.java
+++ b/src/main/java/com/jungdam/invitation/dto/response/UpdateInvitationResponse.java
@@ -1,0 +1,22 @@
+package com.jungdam.invitation.dto.response;
+
+import com.jungdam.invitation.domain.vo.Status;
+
+public class UpdateInvitationResponse {
+
+    private final Long id;
+    private final Status status;
+
+    public UpdateInvitationResponse(Long id, Status status) {
+        this.id = id;
+        this.status = status;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Status getStatus() {
+        return status;
+    }
+}

--- a/src/main/java/com/jungdam/invitation/facade/InvitationFacade.java
+++ b/src/main/java/com/jungdam/invitation/facade/InvitationFacade.java
@@ -7,8 +7,10 @@ import com.jungdam.invitation.converter.InvitationConverter;
 import com.jungdam.invitation.domain.Invitation;
 import com.jungdam.invitation.dto.bundle.CreateInvitationBundle;
 import com.jungdam.invitation.dto.bundle.ReadAllInvitationBundle;
+import com.jungdam.invitation.dto.bundle.UpdateInvitationBundle;
 import com.jungdam.invitation.dto.response.CreateInvitationResponse;
 import com.jungdam.invitation.dto.response.ReadAllInvitationResponse;
+import com.jungdam.invitation.dto.response.UpdateInvitationResponse;
 import com.jungdam.member.application.MemberService;
 import com.jungdam.member.domain.Member;
 import com.jungdam.participant.application.ParticipantService;
@@ -66,4 +68,16 @@ public class InvitationFacade {
 
         return invitationConverter.toReadAllInvitationResponse(invitationList);
     }
+
+    @Transactional
+    public UpdateInvitationResponse update(UpdateInvitationBundle bundle) {
+        Member member = memberService.findById(bundle.getMemberId());
+        Invitation invitation = invitationService.findByIdAndTargetMemberAndPendingStatus(
+            bundle.getInvitationId(), member);
+
+        invitation.updateStatus(bundle.getStatus());
+
+        return invitationConverter.toUpdateInvitationResponse(invitation);
+    }
 }
+

--- a/src/main/java/com/jungdam/invitation/infrastructure/InvitationRepository.java
+++ b/src/main/java/com/jungdam/invitation/infrastructure/InvitationRepository.java
@@ -5,13 +5,16 @@ import com.jungdam.invitation.domain.Invitation;
 import com.jungdam.invitation.domain.vo.Status;
 import com.jungdam.member.domain.Member;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface InvitationRepository extends JpaRepository<Invitation, Long> {
 
-    boolean existsByAlbumAndTargetMemberAndStatus(Album album, Member member, Status status);
+    Optional<Invitation> findByIdAndTargetMemberAndStatus(Long id, Member member, Status status);
 
     List<Invitation> findAllByTargetMemberAndStatus(Member member, Status status);
+
+    boolean existsByAlbumAndTargetMemberAndStatus(Album album, Member member, Status status);
 }

--- a/src/main/java/com/jungdam/invitation/presentation/InvitationController.java
+++ b/src/main/java/com/jungdam/invitation/presentation/InvitationController.java
@@ -5,9 +5,12 @@ import com.jungdam.common.dto.ResponseMessage;
 import com.jungdam.common.utils.SecurityUtils;
 import com.jungdam.invitation.dto.bundle.CreateInvitationBundle;
 import com.jungdam.invitation.dto.bundle.ReadAllInvitationBundle;
+import com.jungdam.invitation.dto.bundle.UpdateInvitationBundle;
 import com.jungdam.invitation.dto.request.CreateInvitationRequest;
+import com.jungdam.invitation.dto.request.UpdateInvitationRequest;
 import com.jungdam.invitation.dto.response.CreateInvitationResponse;
 import com.jungdam.invitation.dto.response.ReadAllInvitationResponse;
+import com.jungdam.invitation.dto.response.UpdateInvitationResponse;
 import com.jungdam.invitation.facade.InvitationFacade;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
@@ -16,6 +19,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -57,5 +61,21 @@ public class InvitationController {
         List<ReadAllInvitationResponse> responseList = invitationFacade.findAllWithPendingStatus(bundle);
 
         return ResponseDto.of(ResponseMessage.INVITATION_READ_ALL_SUCCESS, responseList);
+    }
+
+    @ApiOperation("초대 수락/거절")
+    @PutMapping("/invitations/{invitationId}")
+    public ResponseEntity<ResponseDto<UpdateInvitationResponse>> update(
+        @PathVariable Long invitationId, @RequestBody UpdateInvitationRequest request) {
+        Long memberId = SecurityUtils.getCurrentUsername();
+
+        UpdateInvitationBundle bundle = UpdateInvitationBundle.builder()
+            .memberId(memberId)
+            .invitationId(invitationId)
+            .request(request)
+            .build();
+        UpdateInvitationResponse response = invitationFacade.update(bundle);
+
+        return ResponseDto.of(ResponseMessage.INVITATION_UPDATE_SUCCESS, response);
     }
 }


### PR DESCRIPTION
<!-- 
    PR 제목은 다음과 같은 형식으로 작성합니다.

    gitmoji [Feature/domain-issue number] title
    ex) :sparkles: [Feature/diary-1] 일기 작성 기능 구현
    
    PR에 사용되는 Gitmoji 가이드입니다.
    
    feat(✨) - Introduce new features
    fix(🐛) - Fix a bug
    docs(📝) - Add or update documentation
    style(🎨) - Improve structure / format of the code
    refactor(♻️) - Refactor code
    perf(⚡️) - Improve performance
    test(✅) - Add or update tests
    build(👷) - Add or update CI build system
    ci(💚) - Fix CI Build
    chore(⚙️) - Other changes 
    revert(⏪️) - Revert changes
    hotfix(🚑️) - Critical hotfix
-->


## 💡 개요 
<!-- PR에 대한 설명을 간략하게 작성해주세요. -->
- resolved #34 
- 받은 초대에 대한 수락/거절 기능을 구현하였습니다.


## 📑 작업 사항 
<!-- 진행한 작업에 관한 내용을 작성해주세요. (스크린 샷이 있다면 첨부해주세요) -->
- 초대 수락/거절을 위한 Request, Bundle, Response, Converter 구현
- 초대 수락/거절을 위한 Controller, Facade, Service, Repository 구현

![image](https://user-images.githubusercontent.com/54765850/146406766-480b51fe-144f-47b3-b48f-654a6065b315.png)


## ✒️ 코드 리뷰 요청 사항
<!-- 리뷰어가 집중해서 봐야 하는 포인트나 궁금한 점을 작성해주세요. -->
- Status를 boolean으로 받을까 하다가 Status 타입으로 받기로 했습니다!
- 이렇게 할 경우에 기본 생성자가 없으면 안되더라고요,, requestDto를 final로 하고 싶어서 전체 생성자를 썼었는데 이런 경우까지 생각하면 그냥 기본 생성자로 넣는게 맞는 것 같아서 추후 전체적으로 requestDto 수정 진행하겠습니다.

## ✔️ 코드 리뷰 반영 사항
<!-- 코드 리뷰에 대한 반영사항을 작성해주세요. (재 PR 시에만 작성합니다) -->
- **[08e07f8](https://github.com/jung-dam-diary/team-angelbaby-jungdam-be/pull/115/commits/08e07f8274116f812192c40f2134764bfe22e4a9)** Enum 유효성 검증 로직 추가