### PR TITLE
🐛 [Fix/invitation-117] 초대할 사용자 앨범에 존재 여부 검사 로직 오류 수정

### DIFF
--- a/src/main/java/com/jungdam/invitation/application/InvitationService.java
+++ b/src/main/java/com/jungdam/invitation/application/InvitationService.java
@@ -1,6 +1,8 @@
 package com.jungdam.invitation.application;
 
 import com.jungdam.album.domain.Album;
+import com.jungdam.error.ErrorMessage;
+import com.jungdam.error.exception.DuplicationException;
 import com.jungdam.invitation.domain.Invitation;
 import com.jungdam.invitation.domain.vo.Status;
 import com.jungdam.invitation.infrastructure.InvitationRepository;
@@ -26,14 +28,16 @@ public class InvitationService {
         return invitationRepository.save(invitation);
     }
 
-    @Transactional
-    public boolean existsByAlbumAndTargetMemberAndStatus(Album album, Member member,
-        Status status) {
-        return invitationRepository.existsByAlbumAndTargetMemberAndStatus(album, member, status);
-    }
-
     @Transactional(readOnly = true)
     public List<Invitation> findAllByTargetMemberAndPendingStatus(Member member) {
         return invitationRepository.findAllByTargetMemberAndStatus(member, Status.PENDING);
+    }
+
+    @Transactional(readOnly = true)
+    public void checkExistsInPendingStatus(Album album, Member member) {
+        if (invitationRepository.existsByAlbumAndTargetMemberAndStatus(album, member,
+            Status.PENDING)) {
+            throw new DuplicationException(ErrorMessage.DUPLICATION_INVITATION_IN_ALBUM);
+        }
     }
 }

--- a/src/main/java/com/jungdam/invitation/facade/InvitationFacade.java
+++ b/src/main/java/com/jungdam/invitation/facade/InvitationFacade.java
@@ -2,12 +2,9 @@ package com.jungdam.invitation.facade;
 
 import com.jungdam.album.application.AlbumService;
 import com.jungdam.album.domain.Album;
-import com.jungdam.error.ErrorMessage;
-import com.jungdam.error.exception.DuplicationException;
 import com.jungdam.invitation.application.InvitationService;
 import com.jungdam.invitation.converter.InvitationConverter;
 import com.jungdam.invitation.domain.Invitation;
-import com.jungdam.invitation.domain.vo.Status;
 import com.jungdam.invitation.dto.bundle.CreateInvitationBundle;
 import com.jungdam.invitation.dto.bundle.ReadAllInvitationBundle;
 import com.jungdam.invitation.dto.response.CreateInvitationResponse;
@@ -45,14 +42,9 @@ public class InvitationFacade {
         Member targetMember = memberService.findById(bundle.getTargetMemberId());
         Member subjectMember = memberService.findById(bundle.getSubjectMemberId());
 
-        if (invitationService.existsByAlbumAndTargetMemberAndStatus(album, targetMember,
-            Status.PENDING)) {
-            throw new DuplicationException(ErrorMessage.DUPLICATION_INVITATION_IN_ALBUM);
-        }
+        invitationService.checkExistsInPendingStatus(album, targetMember);
 
-        if (participantService.notExistsByAlbumAndMember(album, targetMember)) {
-            throw new DuplicationException(ErrorMessage.DUPLICATION_PARTICIPANT_IN_ALBUM);
-        }
+        participantService.checkExists(album, targetMember);
 
         Invitation invitation = invitationService.save(
             targetMember,
@@ -65,10 +57,12 @@ public class InvitationFacade {
     }
 
     @Transactional(readOnly = true)
-    public List<ReadAllInvitationResponse> findAllWithPendingStatus(ReadAllInvitationBundle bundle) {
+    public List<ReadAllInvitationResponse> findAllWithPendingStatus(
+        ReadAllInvitationBundle bundle) {
         Member member = memberService.findById(bundle.getMemberId());
 
-        List<Invitation> invitationList = invitationService.findAllByTargetMemberAndPendingStatus(member);
+        List<Invitation> invitationList = invitationService.findAllByTargetMemberAndPendingStatus(
+            member);
 
         return invitationConverter.toReadAllInvitationResponse(invitationList);
     }

--- a/src/main/java/com/jungdam/participant/application/ParticipantService.java
+++ b/src/main/java/com/jungdam/participant/application/ParticipantService.java
@@ -39,6 +39,13 @@ public class ParticipantService {
         }
     }
 
+    @Transactional(readOnly = true)
+    public void checkExists(Album album, Member member) {
+        if (existsByAlbumAndMember(album, member)) {
+            throw new NotExistException(ErrorMessage.DUPLICATION_PARTICIPANT_IN_ALBUM);
+        }
+    }
+
     private boolean existsByAlbumAndMember(Album album, Member member) {
         return participantRepository.existsByAlbumAndMember(album, member);
     }


### PR DESCRIPTION
<!-- 
    PR 제목은 다음과 같은 형식으로 작성합니다.

    gitmoji [Feature/domain-issue number] title
    ex) :sparkles: [Feature/diary-1] 일기 작성 기능 구현
    
    PR에 사용되는 Gitmoji 가이드입니다.
    
    feat(✨) - Introduce new features
    fix(🐛) - Fix a bug
    docs(📝) - Add or update documentation
    style(🎨) - Improve structure / format of the code
    refactor(♻️) - Refactor code
    perf(⚡️) - Improve performance
    test(✅) - Add or update tests
    build(👷) - Add or update CI build system
    ci(💚) - Fix CI Build
    chore(⚙️) - Other changes 
    revert(⏪️) - Revert changes
    hotfix(🚑️) - Critical hotfix
-->


## 💡 개요 
<!-- PR에 대한 설명을 간략하게 작성해주세요. -->
- resolved #117 


## 📑 작업 사항 
<!-- 진행한 작업에 관한 내용을 작성해주세요. (스크린 샷이 있다면 첨부해주세요) -->
- 초대를 할 때 초대 대상 사용자가 앨범에 속해있는지 검사하는 로직이 거꾸로 되어 있어서 수정을 진행하였습니다.
- facade layer에서 예외를 터트리지 않고, service layer로 내렸습니다.


- 초대 성공
  ```json
  {
      "message": "INVITATION_CREATE_SUCCESS",
      "serverDateTime": "2021-12-17T02:17:42.419797",
      "data": {
          "invitationId": 3
      }
  }
  ```
- 중복 된 사용자 초대 실패
  ```json
  {
      "message": "DUPLICATION_INVITATION_IN_ALBUM",
      "serverDateTime": "2021-12-17T02:20:11.634777"
  }
  ```
## ✒️ 코드 리뷰 요청 사항
<!-- 리뷰어가 집중해서 봐야 하는 포인트나 궁금한 점을 작성해주세요. -->


## ✔️ 코드 리뷰 반영 사항
<!-- 코드 리뷰에 대한 반영사항을 작성해주세요. (재 PR 시에만 작성합니다) -->
