### PR TITLE
✨ [Feature/album-30] 앨범 목록 조회 기능 구현

### DIFF
--- a/src/main/java/com/jungdam/album/converter/AlbumConverter.java
+++ b/src/main/java/com/jungdam/album/converter/AlbumConverter.java
@@ -4,12 +4,15 @@ import com.jungdam.album.domain.Album;
 import com.jungdam.album.dto.bundle.CreateAlbumBundle;
 import com.jungdam.album.dto.response.CreateAlbumResponse;
 import com.jungdam.album.dto.response.DeleteAlbumResponse;
+import com.jungdam.album.dto.response.ReadAllAlbumResponse;
 import com.jungdam.album.dto.response.ReadAllMomentResponse;
 import com.jungdam.album.dto.response.ReadOneAlbumResponse;
 import com.jungdam.album.dto.response.UpdateAlbumResponse;
 import com.jungdam.diary.domain.Diary;
 import com.jungdam.member.domain.Member;
+import com.jungdam.participant.domain.Participant;
 import java.util.List;
+import java.util.stream.Collectors;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -30,6 +33,19 @@ public class AlbumConverter {
             .familyMotto(album.getFamilyMottoValue())
             .thumbnail(album.getThumbnailValue())
             .build();
+    }
+
+    public List<ReadAllAlbumResponse> toReadAllAlbumResponse(List<Participant> participants) {
+        return participants.stream()
+            .map(participant -> {
+                Album album = participant.getAlbum();
+                return ReadAllAlbumResponse.builder()
+                    .id(album.getId())
+                    .title(album.getTitleValue())
+                    .familyMotto(album.getFamilyMottoValue())
+                    .thumbnail(album.getThumbnailValue())
+                    .build();
+            }).collect(Collectors.toList());
     }
 
     public ReadOneAlbumResponse toReadOneAlbumResponse(Album album) {

--- a/src/main/java/com/jungdam/album/dto/bundle/ReadAllAlbumBundle.java
+++ b/src/main/java/com/jungdam/album/dto/bundle/ReadAllAlbumBundle.java
@@ -1,0 +1,14 @@
+package com.jungdam.album.dto.bundle;
+
+public class ReadAllAlbumBundle {
+
+    private final Long memberId;
+
+    public ReadAllAlbumBundle(Long memberId) {
+        this.memberId = memberId;
+    }
+
+    public Long getMemberId() {
+        return memberId;
+    }
+}

--- a/src/main/java/com/jungdam/album/dto/response/ReadAllAlbumResponse.java
+++ b/src/main/java/com/jungdam/album/dto/response/ReadAllAlbumResponse.java
@@ -1,0 +1,71 @@
+package com.jungdam.album.dto.response;
+
+public class ReadAllAlbumResponse {
+
+    private final Long id;
+    private final String title;
+    private final String familyMotto;
+    private final String thumbnail;
+
+    public ReadAllAlbumResponse(Long id, String title, String familyMotto, String thumbnail) {
+        this.id = id;
+        this.title = title;
+        this.familyMotto = familyMotto;
+        this.thumbnail = thumbnail;
+    }
+
+    public static ReadAllAlbumResponseBuilder builder() {
+        return new ReadAllAlbumResponseBuilder();
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public String getFamilyMotto() {
+        return familyMotto;
+    }
+
+    public String getThumbnail() {
+        return thumbnail;
+    }
+
+    public static class ReadAllAlbumResponseBuilder {
+
+        private Long id;
+        private String title;
+        private String familyMotto;
+        private String thumbnail;
+
+        private ReadAllAlbumResponseBuilder() {
+        }
+
+        public ReadAllAlbumResponseBuilder id(final Long id) {
+            this.id = id;
+            return this;
+        }
+
+        public ReadAllAlbumResponseBuilder title(final String title) {
+            this.title = title;
+            return this;
+        }
+
+        public ReadAllAlbumResponseBuilder familyMotto(final String familyMotto) {
+            this.familyMotto = familyMotto;
+            return this;
+        }
+
+        public ReadAllAlbumResponseBuilder thumbnail(final String thumbnail) {
+            this.thumbnail = thumbnail;
+            return this;
+        }
+
+        public ReadAllAlbumResponse build() {
+            return new ReadAllAlbumResponse(this.id, this.title, this.familyMotto, this.thumbnail);
+        }
+    }
+}

--- a/src/main/java/com/jungdam/album/facade/AlbumFacade.java
+++ b/src/main/java/com/jungdam/album/facade/AlbumFacade.java
@@ -5,11 +5,13 @@ import com.jungdam.album.converter.AlbumConverter;
 import com.jungdam.album.domain.Album;
 import com.jungdam.album.dto.bundle.CreateAlbumBundle;
 import com.jungdam.album.dto.bundle.DeleteAlbumBundle;
+import com.jungdam.album.dto.bundle.ReadAllAlbumBundle;
 import com.jungdam.album.dto.bundle.ReadAllMomentBundle;
 import com.jungdam.album.dto.bundle.ReadOneAlbumBundle;
 import com.jungdam.album.dto.bundle.UpdateAlbumBundle;
 import com.jungdam.album.dto.response.CreateAlbumResponse;
 import com.jungdam.album.dto.response.DeleteAlbumResponse;
+import com.jungdam.album.dto.response.ReadAllAlbumResponse;
 import com.jungdam.album.dto.response.ReadAllMomentResponse;
 import com.jungdam.album.dto.response.ReadOneAlbumResponse;
 import com.jungdam.album.dto.response.UpdateAlbumResponse;
@@ -18,6 +20,8 @@ import com.jungdam.diary.domain.vo.Bookmark;
 import com.jungdam.member.application.MemberService;
 import com.jungdam.member.domain.Member;
 import com.jungdam.participant.application.ParticipantService;
+import com.jungdam.participant.domain.Participant;
+import java.util.List;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
@@ -51,6 +55,15 @@ public class AlbumFacade {
         Album saveAlbum = albumService.save(album, member);
 
         return albumConverter.toCreateAlbumResponse(saveAlbum);
+    }
+
+    @Transactional(readOnly = true)
+    public List<ReadAllAlbumResponse> findAll(ReadAllAlbumBundle bundle) {
+        Member member = memberService.findById(bundle.getMemberId());
+
+        List<Participant> participants = participantService.findAllByMember(member);
+
+        return albumConverter.toReadAllAlbumResponse(participants);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/jungdam/album/presentation/AlbumController.java
+++ b/src/main/java/com/jungdam/album/presentation/AlbumController.java
@@ -2,6 +2,7 @@ package com.jungdam.album.presentation;
 
 import com.jungdam.album.dto.bundle.CreateAlbumBundle;
 import com.jungdam.album.dto.bundle.DeleteAlbumBundle;
+import com.jungdam.album.dto.bundle.ReadAllAlbumBundle;
 import com.jungdam.album.dto.bundle.ReadAllMomentBundle;
 import com.jungdam.album.dto.bundle.ReadOneAlbumBundle;
 import com.jungdam.album.dto.bundle.UpdateAlbumBundle;
@@ -9,6 +10,7 @@ import com.jungdam.album.dto.request.CreateAlbumRequest;
 import com.jungdam.album.dto.request.UpdateAlbumRequest;
 import com.jungdam.album.dto.response.CreateAlbumResponse;
 import com.jungdam.album.dto.response.DeleteAlbumResponse;
+import com.jungdam.album.dto.response.ReadAllAlbumResponse;
 import com.jungdam.album.dto.response.ReadAllMomentResponse;
 import com.jungdam.album.dto.response.ReadOneAlbumResponse;
 import com.jungdam.album.dto.response.UpdateAlbumResponse;
@@ -18,6 +20,7 @@ import com.jungdam.common.dto.ResponseMessage;
 import com.jungdam.common.utils.SecurityUtils;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
+import java.util.List;
 import java.util.Objects;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -53,6 +56,17 @@ public class AlbumController {
         CreateAlbumResponse response = albumFacade.insert(bundle);
 
         return ResponseDto.of(ResponseMessage.ALBUM_CREATE_SUCCESS, response);
+    }
+
+    @ApiOperation("앨범 목록 조회")
+    @GetMapping
+    public ResponseEntity<ResponseDto<List<ReadAllAlbumResponse>>> getAll() {
+        Long memberId = SecurityUtils.getCurrentUsername();
+
+        ReadAllAlbumBundle bundle = new ReadAllAlbumBundle(memberId);
+        List<ReadAllAlbumResponse> responses = albumFacade.findAll(bundle);
+
+        return ResponseDto.of(ResponseMessage.ALBUM_READ_ALL_SUCCESS, responses);
     }
 
     @ApiOperation("앨범 제목 및 가훈 조회")

--- a/src/main/java/com/jungdam/common/dto/ResponseMessage.java
+++ b/src/main/java/com/jungdam/common/dto/ResponseMessage.java
@@ -20,6 +20,7 @@ public enum ResponseMessage {
     ALBUM_CREATE_SUCCESS(HttpStatus.CREATED, "앨범 생성 성공"),
     MEMBER_SEARCH_SUCCESS(HttpStatus.OK, "회원 검색 성공"),
     ALBUM_READ_SUCCESS(HttpStatus.OK, "앨범 제목 및 가훈 조회 성공"),
+    ALBUM_READ_ALL_SUCCESS(HttpStatus.OK, "앨범 목록 조회 성공"),
     BOOKMARK_MARK_SUCCESS(HttpStatus.OK, "일기 북마크 체크/언체크"),
     ALBUM_DELETE_SUCCESS(HttpStatus.OK, "앨범 삭제 성공"),
     ALBUM_UPDATE_SUCCESS(HttpStatus.OK, "앨범 수정 성공"),

--- a/src/main/java/com/jungdam/participant/application/ParticipantService.java
+++ b/src/main/java/com/jungdam/participant/application/ParticipantService.java
@@ -33,6 +33,11 @@ public class ParticipantService {
     }
 
     @Transactional(readOnly = true)
+    public List<Participant> findAllByMember(Member member) {
+        return participantRepository.findAllByMember(member);
+    }
+
+    @Transactional(readOnly = true)
     public void checkNotExists(Album album, Member member) {
         if (!existsByAlbumAndMember(album, member)) {
             throw new NotExistException(ErrorMessage.NOT_EXIST_PARTICIPANT);

--- a/src/main/java/com/jungdam/participant/infrastructure/ParticipantRepository.java
+++ b/src/main/java/com/jungdam/participant/infrastructure/ParticipantRepository.java
@@ -13,6 +13,8 @@ public interface ParticipantRepository extends JpaRepository<Participant, Long> 
 
     boolean existsByAlbumAndMember(Album album, Member member);
 
+    List<Participant> findAllByMember(Member member);
+
     List<Participant> findAllByAlbum(Album album);
 
     boolean existsByAlbumAndMemberAndRole(Album album, Member member, Role owner);


### PR DESCRIPTION
<!-- 
    PR 제목은 다음과 같은 형식으로 작성합니다.

    gitmoji [Feature/domain-issue number] title
    ex) :sparkles: [Feature/diary-1] 일기 작성 기능 구현
    
    PR에 사용되는 Gitmoji 가이드입니다.
    
    feat(✨) - Introduce new features
    fix(🐛) - Fix a bug
    docs(📝) - Add or update documentation
    style(🎨) - Improve structure / format of the code
    refactor(♻️) - Refactor code
    perf(⚡️) - Improve performance
    test(✅) - Add or update tests
    build(👷) - Add or update CI build system
    ci(💚) - Fix CI Build
    chore(⚙️) - Other changes 
    revert(⏪️) - Revert changes
    hotfix(🚑️) - Critical hotfix
-->


## 💡 개요 
<!-- PR에 대한 설명을 간략하게 작성해주세요. -->
- resolved #30
- 회원이 참여 중인 앨범 목록 조회 기능을 구현하였습니다.


## 📑 작업 사항 
<!-- 진행한 작업에 관한 내용을 작성해주세요. (스크린 샷이 있다면 첨부해주세요) -->
- 앨범 목록 조회를 위한 Bundle, Response, Converter 구현
- 앨범 목록 조회를 위한 Controller, Facade 구현
- 앨범 목록 조회를 위한 ParticipantService, Repository 구현

![image](https://user-images.githubusercontent.com/54765850/146493180-e83f89ee-ea38-46ee-b5ed-be312c4c2490.png)


## ✒️ 코드 리뷰 요청 사항
<!-- 리뷰어가 집중해서 봐야 하는 포인트나 궁금한 점을 작성해주세요. -->
- 이전에 초대 목록 조회에서 발생했던 N + 1 문제와 함께 Converter에서 쿼리가 발생하는 문제가 있습니다. **프론트엔드 측 진행을 위해 일단은 그대로 진행해야 할 것 같아서 추후 리팩토링 과정에서 수정하도록 하겠습니다!**
- 앨범(Album) -> 참여자(Participant) <- 회원(Member)  (앨범과 참여자 1 : N 관계 / 회원과 참여자 1 :N 관계)의 관계에서 회원이 참여하고 있는 앨범에 대한 정보를 조회하고 싶습니다. 현재에는 참여자에서 findByMember를 통해서 회원이 참여하고 있는 목록을 뽑아내고 거기에서 앨범 정보를 조회하는 방식으로 구현했는데 뭔가 잘못된 것 같습니다.. 아이디어나 해결 방법 아시는 분 있으시면 코멘트 남겨주시면 감사하겠습니다. 🙏🙏 (앨범 쪽에서 참여자를 조인 후에 Where을 거는 방법은 없을까요...? )


## ✔️ 코드 리뷰 반영 사항
<!-- 코드 리뷰에 대한 반영사항을 작성해주세요. (재 PR 시에만 작성합니다) -->
